### PR TITLE
Fix instance configurator name

### DIFF
--- a/builder_from_package/run_tyr_beat.sh
+++ b/builder_from_package/run_tyr_beat.sh
@@ -1,14 +1,4 @@
 #!/bin/bash
 
-# we need to wait for the database to be ready
-while ! pg_isready --host=database; do
-    echo "waiting for postgres to be ready"
-    sleep 1;
-done
-
-# export PYTHONPATH=.:../navitiacommon
-
-#db migration
-python /usr/bin/manage_tyr.py db upgrade
-
 exec celery beat -A tyr.tasks
+

--- a/builder_from_package/run_tyr_beat.sh
+++ b/builder_from_package/run_tyr_beat.sh
@@ -1,4 +1,14 @@
 #!/bin/bash
 
-exec celery beat -A tyr.tasks
+# we need to wait for the database to be ready
+while ! pg_isready --host=database; do
+    echo "waiting for postgres to be ready"
+    sleep 1;
+done
 
+# export PYTHONPATH=.:../navitiacommon
+
+#db migration
+python /usr/bin/manage_tyr.py db upgrade
+
+exec celery beat -A tyr.tasks

--- a/builder_from_package/run_tyr_web.sh
+++ b/builder_from_package/run_tyr_web.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # we need to wait for the database to be ready
-while ! pg_isready --host={TYR_DATABASE_HOST}; do
+while ! pg_isready --host=${TYR_DATABASE_HOST}; do
     echo "waiting for postgres to be ready"
     sleep 1;
 done

--- a/builder_from_package/run_tyr_web.sh
+++ b/builder_from_package/run_tyr_web.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# we need to wait for the database to be ready
+while ! pg_isready --host={TYR_DATABASE_HOST}; do
+    echo "waiting for postgres to be ready"
+    sleep 1;
+done
+
 #db migration
 python /usr/bin/manage_tyr.py db upgrade
 echo "MIGRATION IS FINISHED"

--- a/builder_from_package/run_tyr_web.sh
+++ b/builder_from_package/run_tyr_web.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-# we need to wait for the database to be ready
-while ! pg_isready --host=${TYR_DATABASE_HOST}; do
-    echo "waiting for postgres to be ready"
-    sleep 1;
-done
-
 #db migration
 python /usr/bin/manage_tyr.py db upgrade
 echo "MIGRATION IS FINISHED"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,7 +115,6 @@ services:
     ports:
       - "9898:80"
     environment:
-      - TYR_DATABASE_HOST=navitia_database
       - TYR_CITIES_DATABASE_URI=postgresql://navitia:navitia@navitia_cities_database/cities
       - TYR_CITIES_OSM_FILE_PATH=/srv/ed/
       - TYR_CELERY_BROKER_URL=amqp://guest:guest@navitia_rabbitmq:5672//

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ volumes:
 
 services:
   instances_configurator:
+    container_name: navitia_instances_configurator
     image: navitia/instances-configurator:${TAG}
     volumes:
       - tyr_data:/srv/ed
@@ -68,7 +69,6 @@ services:
     ports:
       - "80:80"
     depends_on:
-      - tyr_web
       - database
       - redis
 
@@ -87,7 +87,6 @@ services:
       - TYR_REDIS_HOST=navitia_redis
       - TYR_INSTANCES_DIR=/etc/tyr.d
     depends_on:
-      - tyr_web
       - database
       - cities_database
 
@@ -105,7 +104,6 @@ services:
       - tyr_data:/srv/ed
       - tyr_instance_conf:/etc/tyr.d
     depends_on:
-      - tyr_web
       - database
       - cities_database
 
@@ -117,6 +115,7 @@ services:
     ports:
       - "9898:80"
     environment:
+      - TYR_DATABASE_HOST=navitia_database
       - TYR_CITIES_DATABASE_URI=postgresql://navitia:navitia@navitia_cities_database/cities
       - TYR_CITIES_OSM_FILE_PATH=/srv/ed/
       - TYR_CELERY_BROKER_URL=amqp://guest:guest@navitia_rabbitmq:5672//


### PR DESCRIPTION
After attempting 

https://github.com/hove-io/navitia-docker-compose/pull/122
https://github.com/hove-io/navitia-docker-compose/pull/123
https://github.com/hove-io/navitia-docker-compose/pull/124
https://github.com/hove-io/navitia-docker-compose/pull/125
https://github.com/hove-io/navitia-docker-compose/pull/126
https://github.com/hove-io/navitia-docker-compose/pull/127
https://github.com/hove-io/navitia-docker-compose/pull/128
https://github.com/hove-io/navitia-docker-compose/pull/129
https://github.com/hove-io/navitia-docker-compose/pull/130

Finally a solution was found.

What happened was, after moving the migration from `tyr-beat` script to `tyr-web`, `tyr-beat` started to fire tasks right away without waiting for the `cities_db` to be created and ready, whereas `instances-configurator` was still running to configure `ed_db` and `cities_db`. 

The `instances-configurator` container is set with a fixed container name
 
https://github.com/hove-io/artemis/pull/431/


